### PR TITLE
Fix: call _scrapeops_proxy_enabled() instead of comparing method reference

### DIFF
--- a/scrapeops_scrapy_proxy_sdk/scrapeops_scrapy_proxy_sdk.py
+++ b/scrapeops_scrapy_proxy_sdk/scrapeops_scrapy_proxy_sdk.py
@@ -54,7 +54,7 @@ class ScrapeOpsScrapyProxySdk(object):
         return proxy_url
 
     def _scrapeops_proxy_enabled(self):
-        if self.scrapeops_api_key is None or self.scrapeops_api_key == '' or self.scrapeops_proxy_active == False:
+        if not self.scrapeops_api_key or not self.scrapeops_proxy_active:
             return False
         return True
     

--- a/scrapeops_scrapy_proxy_sdk/scrapeops_scrapy_proxy_sdk.py
+++ b/scrapeops_scrapy_proxy_sdk/scrapeops_scrapy_proxy_sdk.py
@@ -59,7 +59,7 @@ class ScrapeOpsScrapyProxySdk(object):
         return True
     
     def process_request(self, request, spider):
-        if self._scrapeops_proxy_enabled is False or self.scrapeops_endpoint in request.url:
+        if self._scrapeops_proxy_enabled() is False or self.scrapeops_endpoint in request.url:
             return None
         
         scrapeops_url = self._get_scrapeops_url(request)


### PR DESCRIPTION
Closes #3.

`_scrapeops_proxy_enabled` is a method, but `process_request` was comparing the method REFERENCE to `False`:

```python
if self._scrapeops_proxy_enabled is False or ...
```

A method object is never `False`, so this check always evaluates to the right side only, and the early-return never triggers when the proxy should be disabled. The result: every request gets rewritten to `proxy.scrapeops.io` regardless of `SCRAPEOPS_PROXY_ENABLED` or `SCRAPEOPS_API_KEY`.

Adding the missing `()` actually calls the method so its boolean return value is checked.

## Reproduction

1. `pip install scrapeops-scrapy-proxy-sdk==1.0`
2. Register middleware in `DOWNLOADER_MIDDLEWARES`
3. Leave `SCRAPEOPS_API_KEY` unset OR set `SCRAPEOPS_PROXY_ENABLED=False`
4. Run any `scrapy crawl <spider>`
5. Observe: requests rewritten to `https://proxy.scrapeops.io/v1/?api_key=None&url=...` and 401'd

## After this fix

`_scrapeops_proxy_enabled()` correctly returns `False` when `api_key` is `None`/empty or `scrapeops_proxy_active` is `False`, the early-return fires, and requests pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proxy enablement validation to ensure the configured proxy service activates properly during request processing. Requests will now be correctly routed through the proxy endpoint when enabled, restoring expected functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScrapeOps/scrapeops-scrapy-proxy-sdk/pull/4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->